### PR TITLE
Add script to pull prod image from docker hub and upload to Seattle's ECR

### DIFF
--- a/bin/pull-and-push
+++ b/bin/pull-and-push
@@ -4,12 +4,6 @@
 
 set -e
 set +x
-export AWS_DEFAULT_REGION=us-west-2
-REGION=us-west-2
-STACK=civiform-staging
-if [ ! -z "$1" ]; then
-  STACK="$1"
-fi
 
 docker pull docker.io/civiform/civiform:latest
 

--- a/bin/pull-and-push
+++ b/bin/pull-and-push
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+# DOC: Pull prod image from docker hub and upload it to ECR
+
+set -e
+set +x
+export AWS_DEFAULT_REGION=us-west-2
+REGION=us-west-2
+STACK=civiform-staging
+if [ ! -z "$1" ]; then
+  STACK="$1"
+fi
+
+# log the docker CLI into the Docker Hub container registry
+echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
+
+docker pull docker.io/civiform/civiform:latest
+
+# log into AWS ECR
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
+
+# push the Docker Hub image to AWS ECR
+docker tag civiform/civiform:latest public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+docker push public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+
+ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name $STACK | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
+ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name $STACK | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
+
+aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
+
+deadline=$(($(date +%s) + 900))
+until aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"; do
+    if (( $(date +%s) > $deadline )); then
+        echo "deadline exceeded waiting for service update to stabilize"
+        exit 1
+    fi
+done
+
+popd

--- a/bin/pull-and-push
+++ b/bin/pull-and-push
@@ -14,17 +14,17 @@ fi
 # log the docker CLI into the Docker Hub container registry
 echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
 
-docker pull docker.io/civiform/civiform:latest
+docker pull docker.io/civiform/civiform:prod
 
 # log into AWS ECR
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
 
 # push the Docker Hub image to AWS ECR
-docker tag civiform/civiform:latest public.ecr.aws/t1q6b4h2/universal-application-tool:latest
-docker push public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+docker tag civiform/civiform:prod public.ecr.aws/t1q6b4h2/universal-application-tool:prod
+docker push public.ecr.aws/t1q6b4h2/universal-application-tool:prod
 
-ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name $STACK | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
-ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name $STACK | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
+ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
+ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
 
 aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
 

--- a/bin/pull-and-push
+++ b/bin/pull-and-push
@@ -11,29 +11,13 @@ if [ ! -z "$1" ]; then
   STACK="$1"
 fi
 
-# log the docker CLI into the Docker Hub container registry
-echo $DOCKER_HUB_ACCESS_TOKEN | docker login --username $DOCKER_HUB_USERNAME --password-stdin docker.io
-
-docker pull docker.io/civiform/civiform:prod
+docker pull docker.io/civiform/civiform:latest
 
 # log into AWS ECR
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/t1q6b4h2
 
 # push the Docker Hub image to AWS ECR
-docker tag civiform/civiform:prod public.ecr.aws/t1q6b4h2/universal-application-tool:prod
-docker push public.ecr.aws/t1q6b4h2/universal-application-tool:prod
-
-ECSSERVICE=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSService") | .OutputValue')
-ECSCLUSTER=$(aws cloudformation describe-stacks --region ${REGION} --stack-name civiform | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ECSCluster") | .OutputValue')
-
-aws ecs update-service --region=${REGION} --cluster "$ECSCLUSTER" --service "$ECSSERVICE" --force-new-deployment
-
-deadline=$(($(date +%s) + 900))
-until aws ecs wait services-stable --region=${REGION} --cluster "$ECSCLUSTER" --services "$ECSSERVICE"; do
-    if (( $(date +%s) > $deadline )); then
-        echo "deadline exceeded waiting for service update to stabilize"
-        exit 1
-    fi
-done
+docker tag civiform/civiform:latest public.ecr.aws/t1q6b4h2/universal-application-tool:latest
+docker push public.ecr.aws/t1q6b4h2/universal-application-tool:latest
 
 popd


### PR DESCRIPTION
This assumes that we have an image tagged as "prod" in Docker Hub (which I don't think we do yet). We pull from docker hub, log into Seattle's ECR then tag and push to Seattle's ECR with the image pulled from docker.

I haven't tested this yet because we don't yet have the prod tag in docker hub and I don't want to push the wrong image to Seattle's prod account. We also don't have the AWS credentials set up in this repo yet.

Referenced https://github.com/seattle-uat/civiform/blob/main/bin/build-and-push and docs online. 